### PR TITLE
Update timestamp URL in goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
         - >
           osslsigncode sign
             -readpass /tmp/pw
-            -t https://timestamp.digicert.com
+            -t http://timestamp.digicert.com
             -certs /tmp/cert.pem
             -key /tmp/cert.key
             -n "Kube TF Reconciler CLI"


### PR DESCRIPTION
Change timestamp URL from HTTPS to HTTP for signing.